### PR TITLE
dask 2022.5.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - c3i_test2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,7 @@
 channels: 
   cbouss: dask_dev 
+
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
-channels: 
-  cbouss: dask_dev 
-
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"
+# channels: 
+#   cbouss: dask_dev 

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channels:
-  - c3i_test2
+channels: 
+  cbouss: dask_dev 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask" %}
-{% set version = "2022.2.1" %}
+{% set version = "2022.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,17 +7,17 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b699da18d147da84c6c0be26d724dc1ec384960bf1f23c8db4f90740c9ac0a89
+  sha256: 0afd69dd0cd9f838fc0710eda1f3e3333d6603b37e93ded7fac4a51d77566a0f
 build:
   number: 0
-  noarch: python
+  skip: true  # [py<38]
 
 requirements:
   host:
     - python
   run:
     - python >=3.8
-    - bokeh >=2.1.1
+    - bokeh >=2.4.2
     - cytoolz >=0.8.2
     - dask-core {{ version }}
     - distributed {{ version }}
@@ -43,7 +43,8 @@ test:
   requires:
     - pip
   commands:
-    - pip check
+    - pip check || true   # [not win]
+    - pip check || 1      # [win]
 
 #Note: The build and dependency order for dask-distributed packages are as follows.
 #      dask-core --->distributed --->dask
@@ -57,6 +58,7 @@ about:
   description: |
     Dask is a flexible parallel computing library for analytics.
   doc_url: https://dask.org/
+  doc_source_url: https://github.com/dask/dask/tree/main/docs
   dev_url: https://github.com/dask/dask
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,14 +10,14 @@ source:
   sha256: 0afd69dd0cd9f838fc0710eda1f3e3333d6603b37e93ded7fac4a51d77566a0f
 build:
   number: 0
-  skip: true  # [py<38]
+  skip: true
 
 requirements:
   host:
     - python
   run:
     - python >=3.8
-    - bokeh >=2.4.2
+    - bokeh >=2.4.2,<3.0
     - cytoolz >=0.8.2
     - dask-core {{ version }}
     - distributed {{ version }}
@@ -44,8 +44,7 @@ test:
   requires:
     - pip
   commands:
-    - pip check || true   # [not win]
-    - pip check || 1      # [win]
+    - pip check
 
 #Note: The build and dependency order for dask-distributed packages are as follows.
 #      dask-core --->distributed --->dask

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 0afd69dd0cd9f838fc0710eda1f3e3333d6603b37e93ded7fac4a51d77566a0f
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
   skip: true  # [py<38]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - dask-core {{ version }}
     - distributed {{ version }}
     - jinja2
+    - lz4
     - numpy >=1.18
     - pandas >=1.0
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 0afd69dd0cd9f838fc0710eda1f3e3333d6603b37e93ded7fac4a51d77566a0f
 build:
   number: 0
-  skip: true
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 0afd69dd0cd9f838fc0710eda1f3e3333d6603b37e93ded7fac4a51d77566a0f
 build:
   number: 0
+  skip: true # [py<38]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
   host:
     - python
   run:
-    - python >=3.8
+    - python
     - bokeh >=2.4.2,<3.0
     - cytoolz >=0.8.2
     - dask-core {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 0afd69dd0cd9f838fc0710eda1f3e3333d6603b37e93ded7fac4a51d77566a0f
 build:
   number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   skip: true  # [py<38]
 
 requirements:


### PR DESCRIPTION
Update dask-core to 2022.5.0

Version change: bump from 2021.2.1 to 2022.5.0
Changelog: https://docs.dask.org/en/latest/changelog.html
Changes: https://github.com/dask/dask/compare/2022.02.1...2022.05.0?w=0
License: https://github.com/dask/dask/blob/2022.05.0/LICENSE.txt
Upstream Issues: https://github.com/dask/dask/issues
Requirements: https://github.com/dask/dask/blob/2022.05.0/setup.py
Jira: https://anaconda.atlassian.net/browse/DSNC-4808

Actions:
- Update version to 2022.5.0
- Remove noarch
- Add doc_source_url
- Requirement: 
   - update: bokeh >=2.4.2. Add upper bound <3.0 (see https://github.com/AnacondaRecipes/repodata-hotfixes/issues/155)
   - new: lz4 (see https://github.com/dask/distributed/pull/6156 https://github.com/conda-forge/dask-feedstock/pull/176)

Note: The build and dependency order for dask-distributed packages are as follows:
dask-core --->distributed --->dask