### PR TITLE
2023.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,21 +20,20 @@ requirements:
     - wheel
   run:
     - python
-    - bokeh >=2.4.2,<3.0
-    - cytoolz >=0.8.2
+    - bokeh >=2.4.2
+    - click >=8.0
+    - cloudpickle >=1.5.1
     - dask-core {{ version }}
     - distributed {{ version }}
+    - fsspec >=2021.09.0
+    - importlib-metadata >=4.13.0
     - jinja2 >=2.10.3
-    - lz4
     - numpy >=1.21
-    - pandas >=1.3
-    - click >=7.0
-    - cloudpickle >=1.1.1
-    - fsspec >=0.6.0
     - packaging >=20.0
+    - pandas >=1.3
     - partd >=1.2.0
     - pyyaml >=5.3.1
-    - importlib-metadata >=4.13.0
+    - toolz >=0.10.0
   run_constrained:
     - openssl !=1.1.1e
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask" %}
-{% set version = "2023.3.2" %}
+{% set version = "2023.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 51009e92ba9a280bd417633d1ae84f3ed23a8940f0a19594a4b7797ef226fff4
+  sha256: 9dc72ebb509f58f3fe518c12dd5a488c67123fdd66ccb0b968b34fd11e512153
 build:
   number: 0
   skip: true # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ requirements:
     - pandas >=1.3
     - partd >=1.2.0
     - pyyaml >=5.3.1
-    - toolz >=0.10.0
   run_constrained:
     - openssl !=1.1.1e
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - bokeh >=2.4.2,<3.0
     - click >=8.0
     - cloudpickle >=1.5.1
-    - cytools >=0.12.0
+    - cytoolz >=0.12.0
     - dask-core {{ version }}
     - distributed {{ version }}
     - fsspec >=2021.09.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - bokeh >=2.4.2,<3.0
     - click >=8.0
     - cloudpickle >=1.5.1
+    - cytools >=0.10.0
     - dask-core {{ version }}
     - distributed {{ version }}
     - fsspec >=2021.09.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - wheel
   run:
     - python
-    - bokeh >=2.4.2
+    - bokeh >=2.4.2,<3.0
     - click >=8.0
     - cloudpickle >=1.5.1
     - dask-core {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - bokeh >=2.4.2,<3.0
     - click >=8.0
     - cloudpickle >=1.5.1
-    - cytools >=0.10.0
+    - cytools >=0.12.0
     - dask-core {{ version }}
     - distributed {{ version }}
     - fsspec >=2021.09.0


### PR DESCRIPTION
[Upstream](https://github.com/dask/dask)
[Changelog](https://docs.dask.org/en/stable/changelog.html)

### Actions
- Bump version to 2023.4.1
- Update dependencies