### PR TITLE
Pkg 2148 dask 2023.5.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels: 
-  jrice_org: jrice_org

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-#channels: 
-#  avalon-staging: dask_test
+channels: 
+  jrice_org: jrice_org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,21 +21,14 @@ requirements:
   run:
     - python
     - bokeh >=2.4.2,<3.0
-    # - click >=8.0
-    # - cloudpickle >=1.5.1
     - cytoolz >=0.12.0
     - dask-core {{ version }}
     - distributed {{ version }}
-    # - fsspec >=2021.09.0
-    # - importlib-metadata >=4.13.0
     - jinja2 >=2.10.3
     - lz4 >=4.3.2
     - numpy >=1.21
-    # - packaging >=20.0
     - pandas >=1.3
-    # - partd >=1.2.0
     - pyarrow >=7.0                  # [not s390x]
-    # - pyyaml >=5.3.1
   run_constrained:
     - openssl !=1.1.1e
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9dc72ebb509f58f3fe518c12dd5a488c67123fdd66ccb0b968b34fd11e512153
+  sha256: d1b988526012ac2896ace302347e23c003504f8baa69d106b75bd442f089495a
 build:
   number: 0
   skip: true # [py<39]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     # - packaging >=20.0
     - pandas >=1.3
     # - partd >=1.2.0
-    - pyarrow >=7.0
+    - pyarrow >=7.0                  # [not s390x]
     # - pyyaml >=5.3.1
   run_constrained:
     - openssl !=1.1.1e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask" %}
-{% set version = "2023.4.1" %}
+{% set version = "2023.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -10,7 +10,7 @@ source:
   sha256: 9dc72ebb509f58f3fe518c12dd5a488c67123fdd66ccb0b968b34fd11e512153
 build:
   number: 0
-  skip: true # [py<38]
+  skip: true # [py<39]
 
 requirements:
   host:
@@ -21,19 +21,21 @@ requirements:
   run:
     - python
     - bokeh >=2.4.2,<3.0
-    - click >=8.0
-    - cloudpickle >=1.5.1
+    # - click >=8.0
+    # - cloudpickle >=1.5.1
     - cytoolz >=0.12.0
     - dask-core {{ version }}
     - distributed {{ version }}
-    - fsspec >=2021.09.0
-    - importlib-metadata >=4.13.0
+    # - fsspec >=2021.09.0
+    # - importlib-metadata >=4.13.0
     - jinja2 >=2.10.3
+    - lz4 >=4.3.2
     - numpy >=1.21
-    - packaging >=20.0
+    # - packaging >=20.0
     - pandas >=1.3
-    - partd >=1.2.0
-    - pyyaml >=5.3.1
+    # - partd >=1.2.0
+    - pyarrow >=7.0
+    # - pyyaml >=5.3.1
   run_constrained:
     - openssl !=1.1.1e
 
@@ -66,7 +68,7 @@ about:
   summary: Parallel PyData with Task Scheduling
   description: |
     Dask is a flexible parallel computing library for analytics.
-  doc_url: https://docs.dask.org/en/stable/
+  doc_url: https://docs.dask.org/
   dev_url: https://github.com/dask/dask
 
 extra:


### PR DESCRIPTION
# dask 2023.5.1

## Links
- [Jira](https://anaconda.atlassian.net/browse/PKG-2148)
- [Upstream repository](https://github.com/dask/dask/tree/2023.5.1)
_**Please note:** `dask-core` uses the same repo as `dask`. The difference between the two is that `dask-core` is all the [minimum requirements](https://github.com/dask/dask/blob/2023.5.1/pyproject.toml#L29) needed for `dask` to run, while `dask` will contain `dask-core` and some (or all) of its [optional dependencies](https://github.com/dask/dask/blob/2023.5.1/pyproject.toml#L48) (granted no issues arise)_
- **Related Packages:** [`lz4`](https://github.com/AnacondaRecipes/lz4-feedstock/pull/3), [`distributed`](https://github.com/AnacondaRecipes/distributed-feedstock/pull/29) and [`dask-core`](https://github.com/AnacondaRecipes/dask-core-feedstock/pull/31)

--------------------
## Description
- Target channel: `defaults` for Anaconda Distribution 2023.06
### Dependency chain
`dask-core` -> `distributed` -> `dask`
`lz4` -> `dask`

--------------------
### Information checked from upstream: 

- [x] All dependency pinnings match with upstream.
- [x] All URLs are correct.
- [ ] abs.yaml is not present at time of review.

--------------------
### Recipe changes:
- Updated `version` and `sha256`
- Removed `py38` support (according to upstream)
- Updated `doc_url`
- Removed redundant dependencies (all exist in `dask-core`):
     - `click`
     - `cloudpickle`
     - `fsspec`
     - `importlib-metadata`
     - `packaging`
     - `partd`
     - `pyyaml`
- Added optional dependencies to further distinguish from `dask-core` 
     - `lz4`
     - `pyarrow   # [not s390x]`

--------------------
### Tests conducted/Other misc notes:

- Ran `conda-build` locally and it built successfully
- Ran `conda lint` locally and _"All checks OK"_
- Upload to private channel to test compatibility with dependencies was successful