### PR TITLE
Release 2024.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask" %}
-{% set version = "2023.11.0" %}
+{% set version = "2024.4.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 06b8f39755d37ff6ef4db422774db1f1d5d6788d33f0628c80861dc6452f878c
+  sha256: 3d7a516468d96e72581b84c7bb00172366f30d24c689ea4e9bd1334ab6d98f8a
 build:
   number: 0
   skip: true # [py<39]
@@ -20,6 +20,7 @@ requirements:
     - bokeh >=2.4.2
     - cytoolz >=0.12.0
     - dask-core {{ version }}
+    - dask-expr >=1.0,<1.1
     - distributed {{ version }}
     - jinja2 >=2.10.3
     - lz4 >=4.3.2


### PR DESCRIPTION
dask 2024.4.2

**Destination channel:** defaults

### Links

- [PKG-4539](https://anaconda.atlassian.net/browse/PKG-4539) 
- [Upstream repository](https://github.com/dask/dask)
- [Upstream changelog/diff](https://github.com/dask/dask/compare/2023.11.0...2024.4.2#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)
- Relevant dependency PRs:
  - Comparing conda-forge recipe between 2023.11.0 (last version available on defaults) and 2024.4.2 (latest at the moment on conda-forge): https://github.com/conda-forge/dask-feedstock/compare/e3ee0111184684c4e4ec4782b26b0640368eaaee..f813f93485ef0a0b9ce4d09f1c6a40a7327ce8bc

### Explanation of changes:

- Adding `dask-expr` as a dependency, but this isn't going to work as it's not yet on defaults :(


[PKG-4539]: https://anaconda.atlassian.net/browse/PKG-4539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ