### PR TITLE
dask 2024.5.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
+  - https://staging.continuum.io/prefect/fs/dask-core-feedstock/pr34/176887b
   - https://staging.continuum.io/prefect/fs/distributed-feedstock/pr32/85faff3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/dask-core-feedstock/pr34/176887b
-  - https://staging.continuum.io/prefect/fs/distributed-feedstock/pr32/85faff3
-  - https://staging.continuum.io/prefect/fs/dask-expr-feedstock/pr1/51e6fa6

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/distributed-feedstock/pr32/85faff3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/dask-core-feedstock/pr34/176887b
   - https://staging.continuum.io/prefect/fs/distributed-feedstock/pr32/85faff3
+  - https://staging.continuum.io/prefect/fs/dask-expr-feedstock/pr1/51e6fa6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask" %}
-{% set version = "2023.11.0" %}
+{% set version = "2024.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 06b8f39755d37ff6ef4db422774db1f1d5d6788d33f0628c80861dc6452f878c
+  sha256: 324f94cdcd93831d24579021b063a2821099c4d51ec094dbc17e0d3ad1d3d351
 build:
   number: 0
   skip: true # [py<39]
@@ -15,6 +15,11 @@ build:
 requirements:
   host:
     - python
+    - pip
+    - wheel
+    - setuptools
+    - versioneer 0.29
+    - tomli
   run:
     - python
     - bokeh >=2.4.2
@@ -25,7 +30,7 @@ requirements:
     - lz4 >=4.3.2
     - numpy >=1.21
     - pandas >=1.3
-    - pyarrow >=7.0  # [not s390x]
+    - pyarrow >=7.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,8 @@ requirements:
     - python
     - bokeh >=2.4.2
     - cytoolz >=0.12.0
-    - dask-core {{ version }}
-    - distributed {{ version }}
+    - dask-core =={{ version }}
+    - distributed =={{ version }}
     - jinja2 >=2.10.3
     - lz4 >=4.3.2
     - numpy >=1.21

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,7 @@ requirements:
     - numpy >=1.21
     - pandas >=1.3
     - pyarrow >=7.0
-  run_constrained:
-    - dask-expr >= 1.1,<1.2
+    - dask-expr >=1.1,<1.2
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,8 @@ requirements:
     - numpy >=1.21
     - pandas >=1.3
     - pyarrow >=7.0
+  run_constrained:
+    - dask-expr >= 1.1,<1.2
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4539](https://anaconda.atlassian.net/browse/PKG-4539)
- releases: https://github.com/dask/dask/releases
- release-diff: https://github.com/dask/dask/compare/2023.11.0...2024.5.0
- license: https://github.com/dask/dask/blob/main/LICENSE.txt
- requirements-tagged: https://github.com/dask/dask/blob/2024.5.0/pyproject.toml


### Explanation of changes:

- Pin `versioneer` to `0.29`
- Use **=={{ version }}** for `dask-core` and `distributed` to get, e.i., `dask-core 2024.5.0` instead of `dask-core 2024.5.0.*` at runtime
- Use `pyarrow` on all platforms as it's already available on s390x 


### Notes:

- The build and dependency order for dask-distributed packages are as follows:
  -   dask-core -> distributed -> dask




[PKG-4539]: https://anaconda.atlassian.net/browse/PKG-4539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ