### PR TITLE
dask 2025.2.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/distributed-feedstock/pr35/b5860aa

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/distributed-feedstock/pr35/b5860aa
-  - https://staging.continuum.io/prefect/fs/dask-expr-feedstock/pr4/79b2896

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,4 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/prefect/fs/distributed-feedstock/pr35/b5860aa
+  - https://staging.continuum.io/prefect/fs/dask-expr-feedstock/pr4/79b2896

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - numpy >=1.24
     - pandas >=2.0
     - pyarrow >=14.0.1
-    - dask-expr >=1.1,<1.2
+    - dask-expr >=2,<3
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask" %}
-{% set version = "2024.12.1" %}
+{% set version = "2025.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bac809af21c2dd7eb06827bccbfc612504f3ee6435580e548af912828f823195
+  sha256: 89c87125d04d28141eaccc4794164ce9098163fd22d8ad943db48f8d4c815460
 build:
   number: 0
   skip: true # [py<310]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7386](https://anaconda.atlassian.net/browse/PKG-7386)
- [Upstream repository](https://github.com/dask/dask/tree/2025.2.0)
- [Upstream changelog/diff](https://github.com/dask/dask/releases)

### Explanation of changes:

- Update version and sha256
- Update `dask-expr` pinning


[PKG-7386]: https://anaconda.atlassian.net/browse/PKG-7386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ