### PR TITLE
dask 2026.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask" %}
-{% set version = "2026.7.0" %}
+{% set version = "2026.7.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b039970642ce97a063070bae2763dada8aae27e3cbd8ff6d894072f920a1e252
+  sha256: 5727484427665f051e86bf87d021a64d6411141cdc8a20bfe3c1ad2968cc06b7
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask" %}
-{% set version = "2026.6.0" %}
+{% set version = "2026.7.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ae3436bd31ebce2be75edf952bd1fc687a1f11ec03fe8b1bec2903d222344a45
+  sha256: b039970642ce97a063070bae2763dada8aae27e3cbd8ff6d894072f920a1e252
 
 build:
   number: 0


### PR DESCRIPTION
## Links
- Jira: https://anaconda.atlassian.net/browse/PKG-16229
- Dev/project URL: https://github.com/dask/dask
- conda-forge recipe: https://github.com/conda-forge/dask-feedstock
- PyPI: https://pypi.org/project/dask/2026.7.1
- PyPI Inspector: https://inspector.pypi.io/project/dask/2026.7.1

## Changes
- Bump dask from 2026.6.0 to 2026.7.1
- Update sha256 for new source tarball